### PR TITLE
Add linting in GitHub Actions (CI)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: CI
-on: push
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,14 @@
+name: CI
+on: push
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version-file: '.node-version'
+        cache: 'npm'
+    - run: npm install --include=dev
+    - run: npm run lint

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 
 import { useTranslations } from '../../utils/hooks';
 import useFeedback from '../../utils/useFeedback';
-import PageContainer from '../PageContainer';
 import Button from '../Button';
 import Input from '../Input';
+import PageContainer from '../PageContainer';
 
 const Contact = () => {
   const translations = useTranslations();

--- a/src/components/LatLngInput.tsx
+++ b/src/components/LatLngInput.tsx
@@ -1,7 +1,8 @@
-import Input from './Input';
-import { Map, Draggable } from 'pigeon-maps';
 import * as React from 'react';
+
+import { Draggable, Map } from 'pigeon-maps';
 import styled from 'styled-components';
+import Input from './Input';
 
 interface Props {
   disabled?: boolean;

--- a/src/components/OpeningHoursInput.tsx
+++ b/src/components/OpeningHoursInput.tsx
@@ -1,13 +1,13 @@
 import setISODay from 'date-fns/setISODay';
 import * as React from 'react';
-import styled from 'styled-components';
 import { MdSubdirectoryArrowLeft as CopyIcon } from 'react-icons/md';
+import styled from 'styled-components';
 
 import { Lang } from '../contexts/types';
 import { useFormatDate, useTranslations } from '../utils/hooks';
+import Button from './Button';
 import Input from './Input';
 import Tooltip from './Tooltip';
-import Button from './Button';
 
 const InputGroup = styled.div`
   display: flex;


### PR DESCRIPTION
This PR adds a simple GitHub Actions workflow to run on every push that runs `npm run lint`. Correct version of Node is installed according to `.node-version` and dependencies are cached.

Additionally, running `npm run lint` gave some _ordered-imports_ errors so I fixed those.